### PR TITLE
PropertiGrid 控件支持使用 ICustomTypeDescriptor 自定义显示的属性

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
@@ -126,7 +126,7 @@ public class PropertyGrid : Control
     {
         if (obj == null || _itemsControl == null) return;
 
-        _dataView = CollectionViewSource.GetDefaultView(TypeDescriptor.GetProperties(obj.GetType()).OfType<PropertyDescriptor>()
+        _dataView = CollectionViewSource.GetDefaultView(TypeDescriptor.GetProperties(obj).OfType<PropertyDescriptor>()
             .Where(item => PropertyResolver.ResolveIsBrowsable(item)).Select(CreatePropertyItem)
             .Do(item => item.InitElement()));
 


### PR DESCRIPTION
当 PropertiGrid 的 SelectedObject 继承自 ICustomTypeDescriptor 时，TypeDescriptor.GetProperties 的参数应该为对象而不是对象的类型，才能使用 ICustomTypeDescriptor 的接口函数来自定义显示的属性