### PR TITLE
fix：Row错误行数、高度导致响应式布局不生效，具体表现为第一次渲染时容器高度计算错误，鼠标移入控件时触发布局更新，高度才正常

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Panel/Grid/Row.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Panel/Grid/Row.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Threading;
 using HandyControl.Data;
 using HandyControl.Tools;
 using HandyControl.Tools.Extension;
@@ -30,18 +31,89 @@ public class Row : Panel
         set => SetValue(GutterProperty, value);
     }
 
+    // 当视觉父发生变化，订阅父的 SizeChanged / LayoutUpdated，确保在父确定尺寸后重新测量
+    protected override void OnVisualParentChanged(DependencyObject oldParent)
+    {
+        base.OnVisualParentChanged(oldParent);
+        UnsubscribeParentSizeChanged(oldParent as FrameworkElement);
+
+        if (VisualParent is FrameworkElement newParent)
+        {
+            // 如果父已经有具体宽度，可以立即 InvalidateMeasure
+            if (newParent.ActualWidth > 0)
+            {
+                InvalidateMeasure();
+            }
+            else
+            {
+                // 等待父首次布局完成
+                newParent.SizeChanged += Parent_SizeChanged;
+                newParent.LayoutUpdated += Parent_LayoutUpdated;
+            }
+        }
+    }
+
+    private void UnsubscribeParentSizeChanged(FrameworkElement parent)
+    {
+        if (parent == null) return;
+        parent.SizeChanged -= Parent_SizeChanged;
+        parent.LayoutUpdated -= Parent_LayoutUpdated;
+    }
+
+    private void Parent_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (sender is FrameworkElement parent && parent.ActualWidth > 0)
+        {
+            parent.SizeChanged -= Parent_SizeChanged;
+            parent.LayoutUpdated -= Parent_LayoutUpdated;
+            // 延迟到渲染优先级再触发重测，确保父已稳定
+            Dispatcher.BeginInvoke(new Action(InvalidateMeasure), DispatcherPriority.Render);
+        }
+    }
+
+    private void Parent_LayoutUpdated(object sender, EventArgs e)
+    {
+        if (sender is FrameworkElement parent && parent.ActualWidth > 0)
+        {
+            parent.SizeChanged -= Parent_SizeChanged;
+            parent.LayoutUpdated -= Parent_LayoutUpdated;
+            Dispatcher.BeginInvoke(new Action(InvalidateMeasure), DispatcherPriority.Render);
+        }
+    }
+
     protected override Size MeasureOverride(Size constraint)
     {
         var gutter = Gutter;
+
+        // 如果父没有给出有限宽度，尝试用父 ActualWidth
+        if (double.IsInfinity(constraint.Width) || constraint.Width == 0)
+        {
+            if (Parent is FrameworkElement parent && parent.ActualWidth > 0)
+            {
+                constraint = new Size(parent.ActualWidth, constraint.Height);
+            }
+            else
+            {
+                // 延迟再测量一帧，避免返回错误测量尺寸被上层缓存
+                Dispatcher.BeginInvoke(new Action(InvalidateMeasure), DispatcherPriority.Render);
+                // 返回一个合理的最小高度（尽量不要返回 0 宽，否则会导致上层布局认为没有宽度）
+                return new Size(constraint.Width, 0);
+            }
+        }
+
+        // 在 Measure 阶段应该自己根据 constraint 计算 layoutStatus，而不要依赖 _layoutStatus（它在 Arrange 中被设置）
+        var localLayoutStatus = ColLayout.GetLayoutStatus(constraint.Width);
+
         var totalCellCount = 0;
         var totalRowCount = 1;
         _fixedWidth = 0;
         _maxChildDesiredHeight = 0;
         var cols = InternalChildren.OfType<Col>().ToList();
 
+        // 先测量固定或不参与栅格的子元素，累加 fixed 宽度与最大高度
         foreach (var child in cols)
         {
-            var cellCount = child.GetLayoutCellCount(_layoutStatus);
+            var cellCount = child.GetLayoutCellCount(localLayoutStatus);
             if (cellCount == 0 || child.IsFixed)
             {
                 child.Measure(constraint);
@@ -50,18 +122,19 @@ public class Row : Panel
             }
         }
 
-        var itemWidth = (constraint.Width - _fixedWidth + gutter) / ColLayout.ColMaxCellCount;
+        var availableWidth = Math.Max(0, constraint.Width - _fixedWidth + gutter);
+        var itemWidth = availableWidth / ColLayout.ColMaxCellCount;
         itemWidth = Math.Max(0, itemWidth);
 
         foreach (var child in cols)
         {
-            var cellCount = child.GetLayoutCellCount(_layoutStatus);
+            var cellCount = child.GetLayoutCellCount(localLayoutStatus);
             if (cellCount > 0 && !child.IsFixed)
             {
                 totalCellCount += cellCount;
-                var availableWidth = Math.Max(0, cellCount * itemWidth - gutter);
+                var availableChildWidth = Math.Max(0, cellCount * itemWidth - gutter);
 
-                child.Measure(new Size(availableWidth, constraint.Height));
+                child.Measure(new Size(availableChildWidth, constraint.Height));
                 _maxChildDesiredHeight = Math.Max(_maxChildDesiredHeight, child.DesiredSize.Height);
 
                 if (totalCellCount > ColLayout.ColMaxCellCount)
@@ -72,7 +145,9 @@ public class Row : Panel
             }
         }
 
-        return new Size(0, _maxChildDesiredHeight * totalRowCount);
+        // 返回宽度尽量用 constraint.Width（如果是 Infinity 则尝试 parent.ActualWidth），避免返回 0 宽度
+        var returnWidth = double.IsInfinity(constraint.Width) ? (Parent is FrameworkElement p ? p.ActualWidth : 0) : constraint.Width;
+        return new Size(returnWidth, _maxChildDesiredHeight * totalRowCount);
     }
 
     protected override Size ArrangeOverride(Size finalSize)
@@ -80,11 +155,14 @@ public class Row : Panel
         var gutter = Gutter;
         var totalCellCount = 0;
         var cols = InternalChildren.OfType<Col>().ToList();
+
+        // 再次设置布局状态，供 Arrange 使用
+        _layoutStatus = ColLayout.GetLayoutStatus(finalSize.Width);
+
         var itemWidth = (finalSize.Width - _fixedWidth + gutter) / ColLayout.ColMaxCellCount;
         itemWidth = Math.Max(0, itemWidth);
 
         var childBounds = new Rect(0, 0, 0, _maxChildDesiredHeight);
-        _layoutStatus = ColLayout.GetLayoutStatus(finalSize.Width);
 
         foreach (var child in cols)
         {


### PR DESCRIPTION
**失败原因：**
1. Row 在第一次 Measure 时用到了错误的布局状态（_layoutStatus=null）并且父宽度为 Infinity，导致计算出错误的高度。
2. 时序图：
父容器 (StackPanel)
    ↓
调用 Row.Measure(constraint)
    constraint.Width = Infinity   ❌
    |
    ├─ 未设置 _layoutStatus (为 null)
    ├─ 子控件 Measure() 用错误的列数计算宽度
    ├─ Row 返回过大的 Height （假设两倍）
    ↓
Row.Arrange(finalSize)
    ├─ 这里才设置 _layoutStatus ✅
    ├─ 但高度已被父容器缓存，未重新计算 ❌
    ↓
渲染结果：首帧高度过高 → 出现多余空白

鼠标移入（触发布局刷新）
    ↓
重新执行 Measure/Arrange
    constraint.Width 已确定
    _layoutStatus 正确
    ↓
高度恢复正常 ✅

**修复方法：**
1. 通过「独立计算 layoutStatus + 检测 Infinity + 监听父尺寸变化」三步，确保第一次布局就有正确的约束和测量结果，从根本上消除了空白闪动问题。
2. 时序图：
父容器 (StackPanel)
    ↓
调用 Row.Measure(constraint)
    constraint.Width = Infinity
    |
    ├─ 检测到 Infinity → 用 parent.ActualWidth 替代 ✅
    ├─ 即使父未渲染，也安排 Dispatcher.BeginInvoke(InvalidateMeasure) 延迟重测 ✅
    ├─ 当宽度可用时，localLayoutStatus = ColLayout.GetLayoutStatus(width) ✅
    ├─ 子控件正确测量，Row 得出准确高度 ✅
    ↓
Row.Arrange(finalSize)
    ├─ 使用同样 layoutStatus
    ├─ 正常布局所有列 ✅
    ↓
首帧渲染就正确无空白 ✅
