### PR TITLE
轮播图在特性情形下渲染出错

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Carousel/Carousel.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Carousel/Carousel.cs
@@ -196,7 +196,7 @@ public class Carousel : SimpleItemsControl, IDisposable
     /// <summary>
     ///     页码改变事件
     /// </summary>
-    public EventHandler<int> PageIndexChanged;
+    public event EventHandler<int> PageIndexChanged;
 
     /// <summary>
     ///     计时器开关

--- a/src/Shared/HandyControl_Shared/Controls/Carousel/Carousel.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Carousel/Carousel.cs
@@ -190,8 +190,13 @@ public class Carousel : SimpleItemsControl, IDisposable
             else
                 _pageIndex = value;
             UpdatePageButtons(_pageIndex);
+            PageIndexChanged?.Invoke(this, _pageIndex);
         }
     }
+    /// <summary>
+    ///     页码改变事件
+    /// </summary>
+    public EventHandler<int> PageIndexChanged;
 
     /// <summary>
     ///     计时器开关

--- a/src/Shared/HandyControl_Shared/Controls/Carousel/Carousel.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Carousel/Carousel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -372,7 +372,7 @@ public class Carousel : SimpleItemsControl, IDisposable
                 _entryDic[item] = element;
                 ItemsHost.Children.Insert(index, element);
 
-                if (IsLoaded && !_isRefresh && _itemsSourceInternal != null)
+                if (!_isRefresh && _itemsSourceInternal != null)
                 {
                     Items.Insert(index, item);
                 }


### PR DESCRIPTION
### 修改内容：
1. 轮播图在特性情形下渲染出错
2. 顺便增加事件 PageIndexChanged

### 渲染出错图
没有PageButton，并且翻页点击无效。
<img width="1013" height="615" alt="image" src="https://github.com/user-attachments/assets/6c30e5f3-f7a1-41d1-b645-a5046e161652" />

### View
`public MainWindow() 
{
    InitializeComponent();
    DataContext = new MainWindowVm();
}
`

先`InitializeComponent();`再`DataContext = new MainWindowVm();`，会导致`Carousel.Items`没有Add数据。

### ViewModel
`public class MainWindowVm
{
    public List<string> ImageList { get; } = new List<string>()
    {
        "/HandyControlDemo;component/Resources/Img/1.jpg",
        "/HandyControlDemo;component/Resources/Img/2.jpg",
        "/HandyControlDemo;component/Resources/Img/3.jpg",
    };
}`

### XAML
`<hc:Carousel
    Height="330"
    MaxWidth="600"
    Margin="32"
    VerticalAlignment="Center"
    AutoRun="True"
    Background="BurlyWood"
    IsCenter="True"
    ItemsSource="{Binding ImageList}">
    <hc:Carousel.ItemTemplate>
        <DataTemplate>
            <Image
                Width="600"
                Source="{Binding}"
                Stretch="UniformToFill" />
        </DataTemplate>
    </hc:Carousel.ItemTemplate>
</hc:Carousel>`

