### PR TITLE
Remove unnecessary right margin from DataGridCell template

### DIFF
--- a/src/Shared/HandyControl_Shared/Themes/Styles/Base/DataGridBaseStyle.xaml
+++ b/src/Shared/HandyControl_Shared/Themes/Styles/Base/DataGridBaseStyle.xaml
@@ -41,7 +41,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="DataGridCell">
                     <Border Background="Transparent">
-                        <Border Margin="0,0,4,0" CornerRadius="{Binding Path=(hc:BorderElement.CornerRadius),RelativeSource={RelativeSource TemplatedParent}}" Padding="{TemplateBinding Padding}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+                        <Border Margin="0,0,0,0" CornerRadius="{Binding Path=(hc:BorderElement.CornerRadius),RelativeSource={RelativeSource TemplatedParent}}" Padding="{TemplateBinding Padding}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
                             <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                         </Border>
                     </Border>

--- a/src/Shared/HandyControl_Shared/Themes/Theme.xaml
+++ b/src/Shared/HandyControl_Shared/Themes/Theme.xaml
@@ -11947,7 +11947,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="DataGridCell">
 					<Border Background="Transparent">
-						<Border Margin="0,0,4,0" CornerRadius="{Binding Path=(hc:BorderElement.CornerRadius),RelativeSource={RelativeSource TemplatedParent}}" Padding="{TemplateBinding Padding}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+						<Border Margin="0,0,0,0" CornerRadius="{Binding Path=(hc:BorderElement.CornerRadius),RelativeSource={RelativeSource TemplatedParent}}" Padding="{TemplateBinding Padding}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
 							<ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 						</Border>
 					</Border>


### PR DESCRIPTION
Problem

The DataGridCellStyle template has a hardcoded Margin="0,0,4,0" on the inner Border element, which creates an unnecessary 4px gap on the right side of each cell. This makes cells look misaligned and creates unwanted spacing, especially noticeable when editing cells.

Solution

Changed Margin="0,0,4,0" to Margin="0" in the DataGridCell ControlTemplate.

Screenshots

Before:
<img width="136" height="52" alt="Captura de tela 2025-12-17 103417" src="https://github.com/user-attachments/assets/383bc614-a758-4e7b-83bb-bffd423eda05" />

After:
<img width="109" height="42" alt="Captura de tela 2025-12-17 142951" src="https://github.com/user-attachments/assets/8940dafb-1a14-46fc-a4a4-6e56fc02244d" />


Testing

- Tested with DataGrid.Small style
- Cell selection still works correctly
- Editing mode works correctly
- All cell states (selected, editing, inactive) render properly
- No visual regressions found

Files Changed

- src/Shared/HandyControl_Shared/Themes/Styles/Base/DataGridBaseStyle.xaml