### PR TITLE
添加PropertyGrid排序功能和枚举元素优先使用Description作为显示

### DIFF
--- a/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
+++ b/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Media;
 
@@ -15,7 +15,7 @@ public class PropertyGridDemoModel
     [Category("Category2")]
     public bool Boolean { get; set; }
 
-    [Category("Category1")]
+    [Category("Category2")]
     public Gender Enum { get; set; }
 
     public HorizontalAlignment HorizontalAlignment { get; set; }

--- a/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
+++ b/src/Shared/HandyControlDemo_Shared/Data/Model/PropertyGridDemoModel.cs
@@ -27,6 +27,8 @@ public class PropertyGridDemoModel
 
 public enum Gender
 {
+    [Description("Boy/Man/Male")]
     Male,
+    [Description("Girl/Woman/Female")]
     Female
 }

--- a/src/Shared/HandyControlDemo_Shared/UserControl/Controls/PropertyGridDemo.xaml
+++ b/src/Shared/HandyControlDemo_Shared/UserControl/Controls/PropertyGridDemo.xaml
@@ -18,6 +18,15 @@
                         <sys:String>Category1</sys:String>
                     </x:Array>
                 </hc:PropertyGrid.CategoryOrder>
+                <hc:PropertyGrid.PropertyOrder>
+                    <x:Array Type="{x:Type sys:String}">
+                        <sys:String>Boolean</sys:String>
+                        <sys:String>Integer</sys:String>
+                        <sys:String>Enum</sys:String>
+                        <sys:String>String</sys:String>
+                        <sys:String>ImageSource</sys:String>
+                    </x:Array>
+                </hc:PropertyGrid.PropertyOrder>
             </hc:PropertyGrid>
             <StackPanel hc:TitleElement.TitleWidth="168" Grid.Row="1" Margin="20,16,17,10">
                 <TextBox hc:TitleElement.Title="String" hc:TitleElement.TitlePlacement="Left" Style="{StaticResource TextBoxExtend}" Text="{Binding DemoModel.String,Mode=OneWay}" IsReadOnly="True"/>

--- a/src/Shared/HandyControlDemo_Shared/UserControl/Controls/PropertyGridDemo.xaml
+++ b/src/Shared/HandyControlDemo_Shared/UserControl/Controls/PropertyGridDemo.xaml
@@ -1,6 +1,7 @@
-﻿<UserControl x:Class="HandyControlDemo.UserControl.PropertyGridDemo"
+<UserControl x:Class="HandyControlDemo.UserControl.PropertyGridDemo"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:hc="https://handyorg.github.io/handycontrol"
              Background="{DynamicResource RegionBrush}"
              DataContext="{Binding RelativeSource={RelativeSource Self}}">
@@ -10,7 +11,14 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <hc:PropertyGrid Width="500" SelectedObject="{Binding DemoModel}"/>
+            <hc:PropertyGrid Width="500" SelectedObject="{Binding DemoModel}">
+                <hc:PropertyGrid.CategoryOrder>
+                    <x:Array Type="{x:Type sys:String}">
+                        <sys:String>Category2</sys:String>
+                        <sys:String>Category1</sys:String>
+                    </x:Array>
+                </hc:PropertyGrid.CategoryOrder>
+            </hc:PropertyGrid>
             <StackPanel hc:TitleElement.TitleWidth="168" Grid.Row="1" Margin="20,16,17,10">
                 <TextBox hc:TitleElement.Title="String" hc:TitleElement.TitlePlacement="Left" Style="{StaticResource TextBoxExtend}" Text="{Binding DemoModel.String,Mode=OneWay}" IsReadOnly="True"/>
                 <TextBox hc:TitleElement.Title="Enum" hc:TitleElement.TitlePlacement="Left" Style="{StaticResource TextBoxExtend}" Text="{Binding DemoModel.Enum,Mode=OneWay}" IsReadOnly="True" Margin="0,6,0,0"/>

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/Editors/EnumPropertyEditor.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/Editors/EnumPropertyEditor.cs
@@ -1,5 +1,4 @@
 using System;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows;

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/Editors/EnumPropertyEditor.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/Editors/EnumPropertyEditor.cs
@@ -1,6 +1,10 @@
-﻿using System;
+using System;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls.Primitives;
+using HandyControl.Data;
 
 namespace HandyControl.Controls;
 
@@ -9,8 +13,27 @@ public class EnumPropertyEditor : PropertyEditorBase
     public override FrameworkElement CreateElement(PropertyItem propertyItem) => new System.Windows.Controls.ComboBox
     {
         IsEnabled = !propertyItem.IsReadOnly,
-        ItemsSource = Enum.GetValues(propertyItem.PropertyType)
+        ItemsSource = CreateEnumItems(propertyItem.PropertyType),
+        DisplayMemberPath = nameof(EnumItem.Description),
+        SelectedValuePath = nameof(EnumItem.Value)
     };
 
     public override DependencyProperty GetDependencyProperty() => Selector.SelectedValueProperty;
+
+    private static IEnumerable<EnumItem> CreateEnumItems(Type enumType)
+    {
+        foreach (Enum value in Enum.GetValues(enumType))
+        {
+            var fieldInfo = enumType.GetField(value.ToString());
+            var description = fieldInfo?.GetCustomAttributes(typeof(DescriptionAttribute), true) is DescriptionAttribute[] { Length: > 0 } attributes
+                ? attributes[0].Description
+                : value.ToString();
+
+            yield return new EnumItem
+            {
+                Description = description,
+                Value = value
+            };
+        }
+    }
 }

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
+using System;
 using System.ComponentModel;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -102,6 +104,34 @@ public class PropertyGrid : Control
         set => SetValue(ShowSortButtonProperty, ValueBoxes.BooleanBox(value));
     }
 
+    public static readonly DependencyProperty CategoryOrderProperty = DependencyProperty.Register(
+        nameof(CategoryOrder), typeof(IEnumerable<string>), typeof(PropertyGrid),
+        new PropertyMetadata(default(IEnumerable<string>), OnCategoryOrderChanged));
+
+    private static void OnCategoryOrderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var ctl = (PropertyGrid) d;
+        ctl.OnCategoryOrderChanged();
+    }
+
+    protected virtual void OnCategoryOrderChanged()
+    {
+        if (_dataView == null) return;
+
+        UpdateCategoryOrder();
+
+        if (_dataView.GroupDescriptions.OfType<PropertyGroupDescription>().Any(group => group.PropertyName == PropertyItem.CategoryProperty.Name))
+        {
+            SortByCategory(null, null);
+        }
+    }
+
+    public IEnumerable<string> CategoryOrder
+    {
+        get => (IEnumerable<string>) GetValue(CategoryOrderProperty);
+        set => SetValue(CategoryOrderProperty, value);
+    }
+
     public override void OnApplyTemplate()
     {
         if (_searchBar != null)
@@ -130,8 +160,29 @@ public class PropertyGrid : Control
             .Where(item => PropertyResolver.ResolveIsBrowsable(item)).Select(CreatePropertyItem)
             .Do(item => item.InitElement()));
 
+        UpdateCategoryOrder();
+
         SortByCategory(null, null);
         _itemsControl.ItemsSource = _dataView;
+    }
+
+    private void UpdateCategoryOrder()
+    {
+        if (_dataView?.SourceCollection == null) return;
+
+        var categoryOrderDic = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var index = 0;
+
+        foreach (var category in CategoryOrder ?? Enumerable.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(category) || categoryOrderDic.ContainsKey(category)) continue;
+            categoryOrderDic[category] = index++;
+        }
+
+        foreach (var item in _dataView.SourceCollection.OfType<PropertyItem>())
+        {
+            item.CategoryOrder = categoryOrderDic.TryGetValue(item.Category, out var order) ? order : int.MaxValue;
+        }
     }
 
     private void SortByCategory(object sender, ExecutedRoutedEventArgs e)
@@ -142,6 +193,7 @@ public class PropertyGrid : Control
         {
             _dataView.GroupDescriptions.Clear();
             _dataView.SortDescriptions.Clear();
+            _dataView.SortDescriptions.Add(new SortDescription(PropertyItem.CategoryOrderProperty.Name, ListSortDirection.Ascending));
             _dataView.SortDescriptions.Add(new SortDescription(PropertyItem.CategoryProperty.Name, ListSortDirection.Ascending));
             _dataView.SortDescriptions.Add(new SortDescription(PropertyItem.DisplayNameProperty.Name, ListSortDirection.Ascending));
             _dataView.GroupDescriptions.Add(new PropertyGroupDescription(PropertyItem.CategoryProperty.Name));

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
@@ -132,6 +132,34 @@ public class PropertyGrid : Control
         set => SetValue(CategoryOrderProperty, value);
     }
 
+    public static readonly DependencyProperty PropertyOrderProperty = DependencyProperty.Register(
+        nameof(PropertyOrder), typeof(IEnumerable<string>), typeof(PropertyGrid),
+        new PropertyMetadata(default(IEnumerable<string>), OnPropertyOrderChanged));
+
+    private static void OnPropertyOrderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var ctl = (PropertyGrid) d;
+        ctl.OnPropertyOrderChanged();
+    }
+
+    protected virtual void OnPropertyOrderChanged()
+    {
+        if (_dataView == null) return;
+
+        UpdatePropertyOrder();
+
+        if (_dataView.GroupDescriptions.OfType<PropertyGroupDescription>().Any(group => group.PropertyName == PropertyItem.CategoryProperty.Name))
+        {
+            SortByCategory(null, null);
+        }
+    }
+
+    public IEnumerable<string> PropertyOrder
+    {
+        get => (IEnumerable<string>) GetValue(PropertyOrderProperty);
+        set => SetValue(PropertyOrderProperty, value);
+    }
+
     public override void OnApplyTemplate()
     {
         if (_searchBar != null)
@@ -161,6 +189,7 @@ public class PropertyGrid : Control
             .Do(item => item.InitElement()));
 
         UpdateCategoryOrder();
+        UpdatePropertyOrder();
 
         SortByCategory(null, null);
         _itemsControl.ItemsSource = _dataView;
@@ -185,6 +214,25 @@ public class PropertyGrid : Control
         }
     }
 
+    private void UpdatePropertyOrder()
+    {
+        if (_dataView?.SourceCollection == null) return;
+
+        var propertyOrderDic = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var index = 0;
+
+        foreach (var propertyName in PropertyOrder ?? Enumerable.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(propertyName) || propertyOrderDic.ContainsKey(propertyName)) continue;
+            propertyOrderDic[propertyName] = index++;
+        }
+
+        foreach (var item in _dataView.SourceCollection.OfType<PropertyItem>())
+        {
+            item.PropertyOrder = propertyOrderDic.TryGetValue(item.PropertyName, out var order) ? order : int.MaxValue;
+        }
+    }
+
     private void SortByCategory(object sender, ExecutedRoutedEventArgs e)
     {
         if (_dataView == null) return;
@@ -195,6 +243,7 @@ public class PropertyGrid : Control
             _dataView.SortDescriptions.Clear();
             _dataView.SortDescriptions.Add(new SortDescription(PropertyItem.CategoryOrderProperty.Name, ListSortDirection.Ascending));
             _dataView.SortDescriptions.Add(new SortDescription(PropertyItem.CategoryProperty.Name, ListSortDirection.Ascending));
+            _dataView.SortDescriptions.Add(new SortDescription(PropertyItem.PropertyOrderProperty.Name, ListSortDirection.Ascending));
             _dataView.SortDescriptions.Add(new SortDescription(PropertyItem.DisplayNameProperty.Name, ListSortDirection.Ascending));
             _dataView.GroupDescriptions.Add(new PropertyGroupDescription(PropertyItem.CategoryProperty.Name));
         }

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyGrid.cs
@@ -1,5 +1,4 @@
 using System;
-using System;
 using System.ComponentModel;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyItem.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyItem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
@@ -87,6 +87,15 @@ public class PropertyItem : ListBoxItem
     {
         get => (string) GetValue(CategoryProperty);
         set => SetValue(CategoryProperty, value);
+    }
+
+    public static readonly DependencyProperty CategoryOrderProperty = DependencyProperty.Register(
+        nameof(CategoryOrder), typeof(int), typeof(PropertyItem), new PropertyMetadata(default(int)));
+
+    public int CategoryOrder
+    {
+        get => (int) GetValue(CategoryOrderProperty);
+        set => SetValue(CategoryOrderProperty, value);
     }
 
     public static readonly DependencyProperty EditorProperty = DependencyProperty.Register(

--- a/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyItem.cs
+++ b/src/Shared/HandyControl_Shared/Controls/PropertyGrid/PropertyItem.cs
@@ -98,6 +98,15 @@ public class PropertyItem : ListBoxItem
         set => SetValue(CategoryOrderProperty, value);
     }
 
+    public static readonly DependencyProperty PropertyOrderProperty = DependencyProperty.Register(
+        nameof(PropertyOrder), typeof(int), typeof(PropertyItem), new PropertyMetadata(default(int)));
+
+    public int PropertyOrder
+    {
+        get => (int) GetValue(PropertyOrderProperty);
+        set => SetValue(PropertyOrderProperty, value);
+    }
+
     public static readonly DependencyProperty EditorProperty = DependencyProperty.Register(
         nameof(Editor), typeof(PropertyEditorBase), typeof(PropertyItem), new PropertyMetadata(default(PropertyEditorBase)));
 


### PR DESCRIPTION
1.为PropertyGrid添加了Category排序和PropertyItem排序;
2.为EnumPropertyEditor添加优先使用枚举元素的Description作为显示。