### PR TITLE
fix: ComboBox dropdown auto-closes when inside Menu control

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Block/ToggleBlock.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Block/ToggleBlock.cs
@@ -94,7 +94,18 @@ public class ToggleBlock : Control
             e.ChangedButton is MouseButton.Middle && ToggleGesture.MouseAction is MouseAction.MiddleDoubleClick &&
             e.ClickCount == 2)
         {
+            CaptureMouse();
             ControlCommands.Toggle.Execute(null, this);
+        }
+    }
+
+    protected override void OnMouseUp(MouseButtonEventArgs e)
+    {
+        base.OnMouseUp(e);
+
+        if (IsMouseCaptured)
+        {
+            ReleaseMouseCapture();
         }
     }
 


### PR DESCRIPTION

# Problem
ComboBox dropdown auto-closes immediately when placed inside a <Menu> control. The dropdown opens on mouse-down but closes on mouse-up before the user can make a selection.

# Reproduction:

```
<Menu IsMainMenu="True">
    <hc:ComboBox ItemsSource="{Binding DataList}" SelectedIndex="0"/>
</Menu>
```
**Introduced in**: 8e707a66 ("enhance: optimize input elements") — which replaced the standard WPF ToggleButton (with ClickMode="Press" and built-in mouse capture) with a custom ToggleBlock control that lacked mouse capture.

# Root Cause
WPF's Menu control uses PopupControlService to track mouse events and manage popup lifecycles. When the user clicks the ComboBox inside a Menu:

# Fix 
Add mouse capture to ToggleBlock.OnMouseDown to prevent WPF's Menu PopupControlService from closing the parent popup on mouse-up. Without capture, the Menu sees the mouse-up event and closes the hosting MenuItem popup, which cascades to close the ComboBox dropdown.

Fixes #1467